### PR TITLE
entidades, repositorios torneo y partidos, torneo controller

### DIFF
--- a/src/main/java/com/proyecto/cabapro/config/SecurityConfig.java
+++ b/src/main/java/com/proyecto/cabapro/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/", "/login", "/registro", "/css/**", "/js/**","/images/**").permitAll()
-                .requestMatchers("/admin/**").hasRole("ADMIN")
+                .requestMatchers("/admin/**","/torneos/**","/partidos/**").hasRole("ADMIN")
                 .requestMatchers("/arbitro/**").hasRole("ARBITRO")
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/proyecto/cabapro/controller/PartidoController.java
+++ b/src/main/java/com/proyecto/cabapro/controller/PartidoController.java
@@ -1,0 +1,117 @@
+package com.proyecto.cabapro.controller;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.proyecto.cabapro.controller.forms.PartidoForm;
+import com.proyecto.cabapro.model.Partido;
+import com.proyecto.cabapro.model.Torneo;
+import com.proyecto.cabapro.service.PartidoService;
+import com.proyecto.cabapro.service.TorneoService;
+
+import jakarta.validation.Valid;
+
+@Controller
+@RequestMapping("/partidos")
+public class PartidoController {
+
+    private final PartidoService partidoService;
+    private final TorneoService torneoService;
+
+    public PartidoController(PartidoService partidoService,
+                             TorneoService torneoService)
+                              {
+        this.partidoService = partidoService;
+        this.torneoService = torneoService;
+        
+    }
+
+
+    // Form editar
+    @GetMapping("/editar/{id}")
+    public String mostrarFormEditar(@PathVariable("id") int id, Model model) {
+        Partido partido = partidoService.getPartidoById(id).orElse(null);
+        if (partido == null) {
+            return "redirect:/partidos";
+        }
+
+        PartidoForm partidoForm = new PartidoForm();
+        partidoForm.setIdPartido(partido.getIdPartido());
+        partidoForm.setFecha(partido.getFecha());
+        partidoForm.setLugar(partido.getLugar());
+        //cambiar por partidoForm.setEstadoPartido(partido.getEstadoPartido());
+        // Recalcular estado automáticamente
+        partido.setEstadoPartido(partidoService.calcularEstado(partido));
+
+        partidoForm.setEquipoLocal(partido.getEquipoLocal());
+        partidoForm.setEquipoVisitante(partido.getEquipoVisitante());
+        partidoForm.setTorneoId(partido.getTorneo() != null ? partido.getTorneo().getIdTorneo() : null);
+      
+
+        cargarListas(model);
+        model.addAttribute("partidoForm", partidoForm);
+        return "partidos/form";
+    }
+
+    // Actualizar
+    @PostMapping("/actualizar/{id}")
+    public String actualizar(@PathVariable("id") int id,
+                             @Valid @ModelAttribute("partidoForm") PartidoForm partidoForm,
+                             BindingResult result,
+                             Model model) {
+        if (result.hasErrors()) {
+            cargarListas(model);
+            return "partidos/form";
+        }
+
+        Partido partido = partidoService.getPartidoById(id).orElse(null);
+        if (partido == null) {
+            return "redirect:/partidos";
+        }
+
+        Torneo torneo = torneoService.obtenerPorId(partidoForm.getTorneoId());
+        if (torneo == null) {
+            return "redirect:/partidos";
+        }
+
+        partido.setFecha(partidoForm.getFecha());
+        partido.setLugar(partidoForm.getLugar());
+        
+        partido.setEquipoLocal(partidoForm.getEquipoLocal());
+        partido.setEquipoVisitante(partidoForm.getEquipoVisitante());
+        partido.setTorneo(torneo);
+        partido.setEstadoPartido(partidoForm.getEstadoPartido());
+
+
+        try {
+            partidoService.savePartido(partido);
+        } catch (IllegalArgumentException e) {
+            result.rejectValue("fecha", "error.partidoForm", e.getMessage());
+            cargarListas(model);
+            return "partidos/form";
+        }
+            return "redirect:/partidos";
+        }
+
+
+
+    // Helpers
+    private void cargarListas(Model model) {
+        // Torneos activos = fechaFin > ahora
+        List<Torneo> torneosActivos = torneoService.listarTorneos()
+                .stream()
+                .filter(t -> t.getFechaFin() != null && t.getFechaFin().isAfter(LocalDateTime.now()))
+                .collect(Collectors.toList());
+        model.addAttribute("torneos", torneosActivos);
+
+    }
+}

--- a/src/main/java/com/proyecto/cabapro/controller/TorneoController.java
+++ b/src/main/java/com/proyecto/cabapro/controller/TorneoController.java
@@ -1,0 +1,117 @@
+package com.proyecto.cabapro.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.proyecto.cabapro.controller.forms.TorneoForm;
+import com.proyecto.cabapro.model.Torneo;
+import com.proyecto.cabapro.service.TorneoService;
+
+import jakarta.validation.Valid;
+
+@Controller
+@RequestMapping("/torneos")
+public class TorneoController {
+
+    private final TorneoService torneoService;
+
+    public TorneoController(TorneoService torneoService) {
+        this.torneoService = torneoService;
+    }
+
+    // Mostrar lista de torneos
+    @GetMapping
+    public String listar(Model model) {
+        model.addAttribute("torneos", torneoService.listarTorneos());
+        return "torneos/lista";
+    }
+
+    // Formulario de creación
+    @GetMapping("/nuevo")
+    public String mostrarFormNuevo(Model model) {
+        model.addAttribute("torneoForm", new TorneoForm());
+        return "torneos/form";
+    }
+
+    // Guardar torneo nuevo
+    @PostMapping("/guardar")
+    public String guardar(@Valid @ModelAttribute("torneoForm") TorneoForm torneoForm,
+                          BindingResult result) {
+        if (result.hasErrors()) {
+            return "torneos/form";
+        }
+
+        Torneo torneo = new Torneo();
+        torneo.setNombre(torneoForm.getNombre());
+        torneo.setTipoTorneo(torneoForm.getTipoTorneo());
+        torneo.setCategoria(torneoForm.getCategoria());
+        torneo.setFechaInicio(torneoForm.getFechaInicio());
+        torneo.setFechaFin(torneoForm.getFechaFin());
+
+        torneoService.guardarTorneo(torneo);
+        return "redirect:/torneos";
+    }
+
+    // Mostrar formulario de edición
+    @GetMapping("/editar/{id}")
+    public String mostrarFormEditar(@PathVariable("id") int id, Model model) {
+        Torneo torneo = torneoService.obtenerPorId(id);
+        if (torneo == null) {
+            return "redirect:/torneos";
+        }
+
+        TorneoForm torneoForm = new TorneoForm();
+        torneoForm.setIdTorneo(torneo.getIdTorneo());
+        torneoForm.setNombre(torneo.getNombre());
+        torneoForm.setTipoTorneo(torneo.getTipoTorneo());
+        torneoForm.setCategoria(torneo.getCategoria());
+        torneoForm.setFechaInicio(torneo.getFechaInicio());
+        torneoForm.setFechaFin(torneo.getFechaFin());
+
+        model.addAttribute("torneoForm", torneoForm);
+        return "torneos/form";
+    }
+
+    // Actualizar torneo existente
+    @PostMapping("/actualizar/{id}")
+    public String actualizar(@PathVariable("id") int id,
+                             @Valid @ModelAttribute("torneoForm") TorneoForm torneoForm,
+                             BindingResult result) {
+        if (result.hasErrors()) {
+            return "torneos/form";
+        }
+
+        Torneo torneo = torneoService.obtenerPorId(id);
+        if (torneo == null) {
+            // Si el torneo no existe, redirigir a la lista de torneos
+            
+            return "redirect:/torneos";
+        }
+
+        torneo.setNombre(torneoForm.getNombre());
+        torneo.setTipoTorneo(torneoForm.getTipoTorneo());
+        torneo.setCategoria(torneoForm.getCategoria());
+        torneo.setFechaInicio(torneoForm.getFechaInicio());
+        torneo.setFechaFin(torneoForm.getFechaFin());
+
+        torneoService.guardarTorneo(torneo);
+        return "redirect:/torneos";
+    }
+
+    // Eliminar torneo
+    @GetMapping("/eliminar/{id}")
+    public String eliminar(@PathVariable("id") int id) {
+        torneoService.eliminarTorneo(id);
+        return "redirect:/torneos";
+    }
+
+  
+    
+
+}

--- a/src/main/java/com/proyecto/cabapro/controller/forms/PartidoForm.java
+++ b/src/main/java/com/proyecto/cabapro/controller/forms/PartidoForm.java
@@ -1,0 +1,60 @@
+package com.proyecto.cabapro.controller.forms;
+
+import java.time.LocalDateTime;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.proyecto.cabapro.enums.EstadoPartido;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+
+public class PartidoForm {
+
+    private Integer idPartido;
+
+    @NotNull(message = "La fecha es obligatoria")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime fecha;
+
+    @NotEmpty(message = "El lugar es obligatorio")
+    private String lugar;
+
+   
+    private EstadoPartido estadoPartido;
+
+    @NotEmpty(message = "El equipo local es obligatorio")
+    private String equipoLocal;
+
+    @NotEmpty(message = "El equipo visitante es obligatorio")
+    private String equipoVisitante;
+
+    @NotNull(message = "Debe seleccionar un torneo")
+    private Integer torneoId;
+
+
+    // Getters y setters
+    public Integer getIdPartido() { return idPartido; }
+    public void setIdPartido(Integer idPartido) { this.idPartido = idPartido; }
+
+    public LocalDateTime getFecha() { return fecha; }
+    public void setFecha(LocalDateTime fecha) { this.fecha = fecha; }
+
+    public String getLugar() { return lugar; }
+    public void setLugar(String lugar) { this.lugar = lugar; }
+
+    public EstadoPartido getEstadoPartido() { return estadoPartido; }
+    public void setEstadoPartido(EstadoPartido estadoPartido) { this.estadoPartido = estadoPartido; }
+
+    public String getEquipoLocal() { return equipoLocal; }
+    public void setEquipoLocal(String equipoLocal) { this.equipoLocal = equipoLocal; }
+
+    public String getEquipoVisitante() { return equipoVisitante; }
+    public void setEquipoVisitante(String equipoVisitante) { this.equipoVisitante = equipoVisitante; }
+
+    public Integer getTorneoId() { return torneoId; }
+    public void setTorneoId(Integer torneoId) { this.torneoId = torneoId; }
+
+   
+}

--- a/src/main/java/com/proyecto/cabapro/controller/forms/TorneoForm.java
+++ b/src/main/java/com/proyecto/cabapro/controller/forms/TorneoForm.java
@@ -1,0 +1,67 @@
+package com.proyecto.cabapro.controller.forms;
+
+import java.time.LocalDateTime;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.proyecto.cabapro.enums.CategoriaTorneo;
+import com.proyecto.cabapro.enums.TipoTorneo;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+
+public class TorneoForm {
+
+    private Integer idTorneo; // Usado para edición
+
+    @NotEmpty(message = "El nombre es obligatorio")
+    private String nombre;
+
+    @NotNull(message = "El tipo de torneo es obligatorio")
+    private TipoTorneo tipoTorneo;   
+
+    @NotNull(message = "La categoría es obligatoria")
+    private CategoriaTorneo categoria;  
+  
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @NotNull(message = "La fecha de inicio es obligatoria")
+    private LocalDateTime fechaInicio;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @NotNull(message = "La fecha de fin es obligatoria")
+    @Future(message = "La fecha de fin debe estar en el futuro")
+    private LocalDateTime fechaFin;
+
+
+
+    
+
+    // Validación personalizada
+    @AssertTrue(message = "La fecha de fin debe ser posterior al día de inicio (no se permiten eventos el mismo día)")
+    public boolean isFechasValidas() {
+        if (fechaInicio == null || fechaFin == null) return true; // @NotNull lo maneja aparte
+        return fechaFin.toLocalDate().isAfter(fechaInicio.toLocalDate());
+    }
+
+    // Getters y setters
+    public Integer getIdTorneo() { return idTorneo; }
+    public void setIdTorneo(Integer idTorneo) { this.idTorneo = idTorneo; }
+
+    public String getNombre() { return nombre; }
+    public void setNombre(String nombre) { this.nombre = nombre; }
+
+    public TipoTorneo getTipoTorneo() { return tipoTorneo; }
+    public void setTipoTorneo(TipoTorneo tipoTorneo) { this.tipoTorneo = tipoTorneo; }
+
+    public CategoriaTorneo getCategoria() { return categoria; }
+    public void setCategoria(CategoriaTorneo categoria) { this.categoria = categoria; }
+
+    public LocalDateTime getFechaInicio() { return fechaInicio; }
+    public void setFechaInicio(LocalDateTime fechaInicio) { this.fechaInicio = fechaInicio; }
+
+    public LocalDateTime getFechaFin() { return fechaFin; }
+    public void setFechaFin(LocalDateTime fechaFin) { this.fechaFin = fechaFin; }
+}

--- a/src/main/java/com/proyecto/cabapro/enums/CategoriaTorneo.java
+++ b/src/main/java/com/proyecto/cabapro/enums/CategoriaTorneo.java
@@ -1,0 +1,7 @@
+package com.proyecto.cabapro.enums;
+
+public enum CategoriaTorneo {
+    UNIVERSITARIO,
+    AMATEUR,
+    PROFESIONAL
+}

--- a/src/main/java/com/proyecto/cabapro/enums/EstadoPartido.java
+++ b/src/main/java/com/proyecto/cabapro/enums/EstadoPartido.java
@@ -1,0 +1,9 @@
+package com.proyecto.cabapro.enums;
+
+public enum EstadoPartido {
+    PROGRAMADO,
+    EN_CURSO,
+    FINALIZADO,
+    CANCELADO,
+   
+}

--- a/src/main/java/com/proyecto/cabapro/enums/TipoTorneo.java
+++ b/src/main/java/com/proyecto/cabapro/enums/TipoTorneo.java
@@ -1,0 +1,7 @@
+package com.proyecto.cabapro.enums;
+
+public enum TipoTorneo {
+    LIGA,
+    ELIMINACION_DIRECTA,
+    TORNEO_CORTO
+}

--- a/src/main/java/com/proyecto/cabapro/model/Administrador.java
+++ b/src/main/java/com/proyecto/cabapro/model/Administrador.java
@@ -16,9 +16,11 @@ import jakarta.persistence.Table;
 @PrimaryKeyJoinColumn(name = "id") // usa la misma PK del padre
 public class Administrador extends Usuario {
     // Por ahora NO agregamos campos propios.
-   
+    // Si luego necesitas algo propio (p. ej. "oficina", "extensionTelefono"),
+    // los agregas aquí como propiedades normales.
     
     public Administrador() {
+        // Requerido por JPA
     }
 
     // Puedes agregar constructores de conveniencia si deseas.

--- a/src/main/java/com/proyecto/cabapro/model/Partido.java
+++ b/src/main/java/com/proyecto/cabapro/model/Partido.java
@@ -1,0 +1,118 @@
+package com.proyecto.cabapro.model;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.proyecto.cabapro.enums.EstadoPartido;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "partidos")
+public class Partido {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int idPartido;
+
+    private LocalDateTime fecha;
+    private String lugar;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado_partido")
+    private EstadoPartido estadoPartido = EstadoPartido.PROGRAMADO; // valor por defecto
+
+    private String equipoLocal;
+    private String equipoVisitante;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="torneo_id")
+    private Torneo torneo;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "partido_arbitro",
+        joinColumns = @JoinColumn(name = "partido_id"),
+        inverseJoinColumns = @JoinColumn(name = "arbitro_id")
+    )
+    private List<Arbitro> arbitros = new ArrayList<>();
+
+    // Getters y Setters
+    public int getIdPartido() {
+        return idPartido;
+    }
+
+    public void setIdPartido(int idPartido) {
+        this.idPartido = idPartido;
+    }
+
+    public LocalDateTime getFecha() {
+        return fecha;
+    }
+
+    public void setFecha(LocalDateTime fecha) {
+        this.fecha = fecha;
+    }
+
+    public String getLugar() {
+        return lugar;
+    }
+
+    public void setLugar(String lugar) {
+        this.lugar = lugar;
+    }
+
+
+
+    public EstadoPartido getEstadoPartido() {
+    return estadoPartido;
+    }
+
+    public void setEstadoPartido(EstadoPartido estadoPartido) {
+        this.estadoPartido = estadoPartido;
+    }
+
+    public String getEquipoLocal() {
+        return equipoLocal;
+    }
+
+    public void setEquipoLocal(String equipoLocal) {
+        this.equipoLocal = equipoLocal;
+    }
+
+    public String getEquipoVisitante() {
+        return equipoVisitante;
+    }
+
+    public void setEquipoVisitante(String equipoVisitante) {
+        this.equipoVisitante = equipoVisitante;
+    }
+
+    public Torneo getTorneo() {
+        return torneo;
+    }
+
+    public void setTorneo(Torneo torneo) {
+        this.torneo = torneo;
+    }
+
+    public List<Arbitro> getArbitros() {
+        return arbitros;
+    }
+
+    public void setArbitros(List<Arbitro> arbitros) {
+        this.arbitros = arbitros;
+    }
+}

--- a/src/main/java/com/proyecto/cabapro/model/Torneo.java
+++ b/src/main/java/com/proyecto/cabapro/model/Torneo.java
@@ -1,0 +1,101 @@
+package com.proyecto.cabapro.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.proyecto.cabapro.enums.CategoriaTorneo;
+import com.proyecto.cabapro.enums.TipoTorneo;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "torneos")
+public class Torneo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int idTorneo;
+
+    private String nombre;      
+    
+    @Enumerated(EnumType.STRING)
+    private TipoTorneo tipoTorneo;
+    
+    @Enumerated(EnumType.STRING) // <-- guarda el nombre del enum (no el número)
+    private CategoriaTorneo categoria;
+
+    private LocalDateTime fechaInicio;
+    private LocalDateTime fechaFin;
+
+    @OneToMany(mappedBy = "torneo", fetch = FetchType.LAZY, cascade = CascadeType.ALL)  // cargar partidos solo si los pides
+    private List<Partido> partidos;
+
+    // Getters y Setters
+    public int getIdTorneo() {
+        return idTorneo;
+    }
+
+    public void setIdTorneo(int idTorneo) {
+        this.idTorneo = idTorneo;
+    }
+
+    public String getNombre() {   
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {  
+        this.nombre = nombre;
+    }
+
+    public TipoTorneo getTipoTorneo() {
+    return tipoTorneo;
+}
+
+    public void setTipoTorneo(TipoTorneo tipoTorneo) {
+        this.tipoTorneo = tipoTorneo;
+    }
+
+
+    
+
+    public CategoriaTorneo getCategoria() {
+        return categoria;
+    }
+
+    public void setCategoria(CategoriaTorneo categoria) {
+        this.categoria = categoria;
+    }
+
+    public LocalDateTime getFechaInicio() {
+        return fechaInicio;
+    }
+
+    public void setFechaInicio(LocalDateTime fechaInicio) {
+        this.fechaInicio = fechaInicio;
+    }
+
+    public LocalDateTime getFechaFin() {
+        return fechaFin;
+    }
+
+    public void setFechaFin(LocalDateTime fechaFin) {
+        this.fechaFin = fechaFin;
+    }
+
+    public List<Partido> getPartidos() {
+        return partidos;
+    }
+
+    public void setPartidos(List<Partido> partidos) {
+        this.partidos = partidos;
+    }
+}

--- a/src/main/java/com/proyecto/cabapro/repository/ArbitroRepository.java
+++ b/src/main/java/com/proyecto/cabapro/repository/ArbitroRepository.java
@@ -6,8 +6,6 @@ import com.proyecto.cabapro.model.Arbitro;
 
 public interface ArbitroRepository extends JpaRepository<Arbitro, Integer> {
 
-    
-
 }
 
 

--- a/src/main/java/com/proyecto/cabapro/repository/PartidoRepository.java
+++ b/src/main/java/com/proyecto/cabapro/repository/PartidoRepository.java
@@ -1,0 +1,41 @@
+package com.proyecto.cabapro.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.proyecto.cabapro.enums.EstadoPartido;
+import com.proyecto.cabapro.model.Partido;
+
+@Repository
+public interface PartidoRepository extends JpaRepository<Partido, Integer> {
+
+    List<Partido> findByTorneo_IdTorneo(int torneoId);
+
+    // CORREGIDO: coincide con el nombre del campo del ID en Arbitro/Usuario
+    List<Partido> findByArbitros_Id(int idArbitro);
+
+    // ahora con enum
+    List<Partido> findByEstadoPartido(EstadoPartido estado);
+
+    // torneos + estado (enum)
+    List<Partido> findByTorneo_IdTorneoAndEstadoPartido(int torneoId, EstadoPartido estado);
+
+ 
+
+    List<Partido> findByEquipoLocal(String equipoLocal);
+
+    List<Partido> findByEquipoVisitante(String equipoVisitante);
+       // opcional: traer partidos de un torneo con árbitros (evita N+1)
+   
+    @Query("SELECT DISTINCT p FROM Partido p " +
+           "JOIN FETCH p.torneo t " +
+           "LEFT JOIN FETCH p.arbitros a " +
+           "WHERE t.idTorneo = :torneoId")
+    List<Partido> findByTorneoWithArbitros(@Param("torneoId") int torneoId);
+
+}
+

--- a/src/main/java/com/proyecto/cabapro/repository/TorneoRepository.java
+++ b/src/main/java/com/proyecto/cabapro/repository/TorneoRepository.java
@@ -1,0 +1,23 @@
+package com.proyecto.cabapro.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.proyecto.cabapro.enums.CategoriaTorneo;
+import com.proyecto.cabapro.enums.TipoTorneo;
+import com.proyecto.cabapro.model.Torneo;
+
+public interface TorneoRepository extends JpaRepository<Torneo, Integer> {
+
+    
+    List<Torneo> findByTipoTorneo(TipoTorneo tipoTorneo);
+    List<Torneo> findByCategoria(CategoriaTorneo categoria);
+
+    List<Torneo> findByFechaFinAfter(LocalDateTime fechaActual);
+    List<Torneo> findByFechaInicioBetween(LocalDateTime inicio, LocalDateTime fin);
+
+    Optional<Torneo> findByNombre(String nombre);
+}

--- a/src/main/java/com/proyecto/cabapro/service/PartidoService.java
+++ b/src/main/java/com/proyecto/cabapro/service/PartidoService.java
@@ -1,0 +1,147 @@
+package com.proyecto.cabapro.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.proyecto.cabapro.controller.forms.PartidoForm;
+import com.proyecto.cabapro.enums.EstadoPartido;
+import com.proyecto.cabapro.model.Partido;
+import com.proyecto.cabapro.model.Torneo;
+import com.proyecto.cabapro.repository.PartidoRepository;
+
+@Service
+public class PartidoService {
+
+    @Autowired
+    private PartidoRepository partidoRepository;
+
+
+    public List<Partido> getAllPartidos() {
+        return partidoRepository.findAll();
+    }
+
+    public Optional<Partido> getPartidoById(int id) {
+        return partidoRepository.findById(id);
+    }
+
+
+
+
+    // Reemplaza este método con validación
+    public Partido savePartido(Partido partido) {
+        var torneo = partido.getTorneo();
+        if (torneo == null) {
+            throw new IllegalArgumentException("Debe seleccionar un torneo");
+        }
+
+        if (torneo.getFechaInicio() != null && partido.getFecha().isBefore(torneo.getFechaInicio())) {
+            throw new IllegalArgumentException("La fecha del partido no puede ser antes del inicio del torneo");
+        }
+        if (torneo.getFechaFin() != null && partido.getFecha().isAfter(torneo.getFechaFin())) {
+            throw new IllegalArgumentException("La fecha del partido no puede ser después de la finalización del torneo");
+        }
+
+        return partidoRepository.save(partido);
+    }
+
+    public Partido crearPartido(PartidoForm form, Torneo torneo) {
+        Partido partido = new Partido();
+        partido.setFecha(form.getFecha());
+        partido.setLugar(form.getLugar());
+        partido.setEquipoLocal(form.getEquipoLocal());
+        partido.setEquipoVisitante(form.getEquipoVisitante());
+        partido.setEstadoPartido(EstadoPartido.PROGRAMADO);
+        partido.setTorneo(torneo);
+        return savePartido(partido); // ya valida fechas
+    }
+
+    public Partido actualizarPartido(Partido partido, PartidoForm form) {
+        partido.setFecha(form.getFecha());
+        partido.setLugar(form.getLugar());
+        partido.setEquipoLocal(form.getEquipoLocal());
+        partido.setEquipoVisitante(form.getEquipoVisitante());
+        partido.setEstadoPartido(form.getEstadoPartido());
+        return savePartido(partido);
+    }
+
+
+
+    public void deletePartido(int id) {
+        partidoRepository.deleteById(id);
+    }
+
+    public List<Partido> getPartidosByTorneo(int torneoId) {
+        return partidoRepository.findByTorneo_IdTorneo(torneoId);
+    }
+    public List<Partido> obtenerPorTorneo(Torneo torneo) {
+        return partidoRepository.findByTorneo_IdTorneo(torneo.getIdTorneo());
+    }
+
+
+    public List<Partido> getPartidosByArbitro(int arbitroId) {
+    return partidoRepository.findByArbitros_Id(arbitroId);
+    }
+
+
+    public List<Partido> getPartidosByEstado(EstadoPartido estado) {
+        List<Partido> partidos = partidoRepository.findByEstadoPartido(estado);
+        partidos.forEach(this::actualizarEstado);
+        return partidos;
+    }
+
+    public List<Partido> getPartidosByTorneoAndEstado(int torneoId, EstadoPartido estado) {
+        List<Partido> partidos = partidoRepository.findByTorneo_IdTorneoAndEstadoPartido(torneoId, estado);
+        partidos.forEach(this::actualizarEstado);
+        return partidos;
+    }
+
+    public List<Partido> getPartidosByEquipoLocal(String equipoLocal) {
+        return partidoRepository.findByEquipoLocal(equipoLocal);
+    }
+
+    public List<Partido> getPartidosByEquipoVisitante(String equipoVisitante) {
+        return partidoRepository.findByEquipoVisitante(equipoVisitante);
+    }
+
+    public EstadoPartido calcularEstado(Partido partido) {
+            actualizarEstado(partido); 
+        return partido.getEstadoPartido();
+    }
+
+    
+    // ---------------- Lógica de estado ----------------
+    /**
+     * Actualiza el estado del partido según la fecha actual.
+     * - Si fecha == null -> no hace nada.
+     * - Si ya CANCELADO -> no cambia.
+     * - Usa duración por defecto de 120 minutos (ajusta para pruebas).
+     */
+  
+
+    // ---- Nuevo método ----
+    public void actualizarEstado(Partido partido) {
+        if (partido.getFecha() == null) return;
+        if (partido.getEstadoPartido() == EstadoPartido.CANCELADO) return;
+
+        LocalDateTime ahora = LocalDateTime.now();
+        long duracionMinutos = 20L; //  parametrizar
+
+        LocalDateTime inicio = partido.getFecha();
+        LocalDateTime fin = inicio.plusMinutes(duracionMinutos);
+
+        if (ahora.isBefore(inicio)) {
+            partido.setEstadoPartido(EstadoPartido.PROGRAMADO);
+        } else if (!ahora.isBefore(inicio) && ahora.isBefore(fin)) {
+            partido.setEstadoPartido(EstadoPartido.EN_CURSO);
+        } else {
+            partido.setEstadoPartido(EstadoPartido.FINALIZADO);
+        }
+    }
+
+
+
+}

--- a/src/main/java/com/proyecto/cabapro/service/TorneoService.java
+++ b/src/main/java/com/proyecto/cabapro/service/TorneoService.java
@@ -1,0 +1,49 @@
+package com.proyecto.cabapro.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.proyecto.cabapro.model.Torneo;
+import com.proyecto.cabapro.repository.TorneoRepository;
+
+// TorneoService.java
+// Clase de servicio que contiene la lógica de negocio relacionada con los torneos.
+// Actúa como intermediario entre los controladores y el repositorio.
+@Service
+public class TorneoService {
+
+    // Repositorio para acceder a los datos de Torneo en la base de datos
+    private final TorneoRepository torneoRepository;
+
+    // Constructor con inyección de dependencias
+    public TorneoService(TorneoRepository torneoRepository) {
+        this.torneoRepository = torneoRepository;
+    }
+
+    // Guarda o actualiza un torneo en la base de datos
+    public Torneo guardarTorneo(Torneo torneo) {
+        return torneoRepository.save(torneo);
+    }
+
+    // Devuelve la lista completa de torneos
+    public List<Torneo> listarTorneos() {
+        return torneoRepository.findAll();
+    }
+
+    // Obtiene un torneo por su ID, devuelve null si no existe
+    public Torneo obtenerPorId(int id) {
+        return torneoRepository.findById(id).orElse(null);
+    }
+
+    // Obtiene un torneo por su nombre, devuelve Optional para manejar el caso "no encontrado"
+    public Optional<Torneo> obtenerPorNombre(String nombre) {
+        return torneoRepository.findByNombre(nombre);
+    }
+
+    // Elimina un torneo por su ID
+    public void eliminarTorneo(int id) {
+        torneoRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title th:text="${partidoForm.idPartido != null} ? 'Editar Partido' : 'Crear Partido'">Formulario Partido</title>
+
+  <!-- Bootstrap -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <!-- Tipografía y colores globales -->
+  <link rel="stylesheet" href="/css/globals.css">
+  <link rel="stylesheet" href="/css/forms.css">
+  <link rel="stylesheet" href="/css/home.css">
+  <link rel="stylesheet" href="/css/header.css">
+  <link rel="stylesheet" href="/css/footer.css">
+</head>
+<body>
+  <!-- HEADER -->
+  <div th:replace="fragments/header :: header"></div>
+
+  <!-- FORMULARIO -->
+  <main class="container my-5">
+    <div class="row justify-content-center">
+      <div class="col-md-8 col-lg-6">
+        <div class="card p-4 shadow-sm rounded-3">
+          <h2 class="mb-4 text-center" th:text="${partidoForm.idPartido != null} ? 'Editar Partido' : 'Crear Partido'"></h2>
+
+          <div class="alert alert-danger" th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+          <form th:action="@{${partidoForm.idPartido} != null ? 
+            '/torneos/' + ${partidoForm.torneoId} + '/partidos/' + ${partidoForm.idPartido} + '/actualizar' :
+            '/torneos/' + ${partidoForm.torneoId} + '/partidos/guardar'}"
+            th:object="${partidoForm}" method="post" class="needs-validation" novalidate>
+
+            <input type="hidden" th:field="*{idPartido}"/>
+            <input type="hidden" th:field="*{torneoId}"/>
+
+            <div class="mb-3">
+              <label class="form-label">Fecha</label>
+              <input type="datetime-local" th:field="*{fecha}" class="form-control"/>
+              <div class="text-danger small" th:if="${#fields.hasErrors('fecha')}" th:errors="*{fecha}"></div>
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Lugar</label>
+              <input type="text" th:field="*{lugar}" class="form-control"/>
+              <div class="text-danger small" th:if="${#fields.hasErrors('lugar')}" th:errors="*{lugar}"></div>
+            </div>
+
+            <div class="mb-3" th:if="${partidoForm.idPartido != null}">
+              <label class="form-label">Estado</label>
+              <select th:field="*{estadoPartido}" class="form-select">
+                <option value="PROGRAMADO">Programado</option>
+                <option value="CANCELADO">Cancelado</option>
+              </select>
+              <div class="text-danger small" th:if="${#fields.hasErrors('estadoPartido')}" th:errors="*{estadoPartido}"></div>
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Equipo Local</label>
+              <input type="text" th:field="*{equipoLocal}" class="form-control"/>
+              <div class="text-danger small" th:if="${#fields.hasErrors('equipoLocal')}" th:errors="*{equipoLocal}"></div>
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Equipo Visitante</label>
+              <input type="text" th:field="*{equipoVisitante}" class="form-control"/>
+              <div class="text-danger small" th:if="${#fields.hasErrors('equipoVisitante')}" th:errors="*{equipoVisitante}"></div>
+            </div>
+
+            <div class="d-grid mt-4">
+              <button type="submit" 
+                      class="btn btn-cta btn-md btn-caba-naranja"
+                      th:text="${partidoForm.idPartido != null} ? 'Actualizar' : 'Crear'">
+              </button>
+
+            </div>
+
+          </form>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <!-- FOOTER -->
+  <div th:replace="fragments/footer :: footer"></div>
+
+  <!-- Scripts -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/lista.html
+++ b/src/main/resources/templates/lista.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Lista de Partidos</title></head>
+<body>
+<h1>Lista de Partidos</h1>
+<a th:href="@{/partidos/nuevo}">Crear nuevo partido</a>
+<table border="1">
+    <thead>
+    <tr>
+        <th>ID</th><th>Fecha</th><th>Lugar</th><th>Estado</th>
+        <th>Local</th><th>Visitante</th><th>Torneo</th><th>Árbitros</th><th>Acciones</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="partido : ${partidos}">
+        <td th:text="${partido.idPartido}"></td>
+        <td th:text="${partido.fecha}"></td>
+        <td th:text="${partido.lugar}"></td>
+        <td th:text="${partido.estadoPartido}"></td>
+        <td th:text="${partido.equipoLocal}"></td>
+        <td th:text="${partido.equipoVisitante}"></td>
+        <td th:text="${partido.torneo.nombre}"></td>
+        <td>
+            <span th:each="arb : ${partido.arbitros}" th:text="${arb.nombre} + ' '"></span>
+        </td>
+        <td>
+            <a th:href="@{'/partidos/editar/' + ${partido.idPartido}}">Editar</a> |
+            <a th:href="@{'/partidos/eliminar/' + ${partido.idPartido}}"
+               onclick="return confirm('¿Eliminar este partido?');">Eliminar</a>
+            <a th:href="@{'/asignacion/crear?partidoId=' + ${partido.idPartido}}">Asignar árbitros</a>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/partidos/form.html
+++ b/src/main/resources/templates/partidos/form.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title th:text="${partidoForm.idPartido != null} ? 'Editar Partido' : 'Crear Partido'">Formulario Partido</title>
+
+  <!-- Bootstrap -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <!-- Tipografía y colores globales -->
+  <link rel="stylesheet" href="/css/globals.css">
+  <link rel="stylesheet" href="/css/forms.css">
+  <link rel="stylesheet" href="/css/home.css">
+  <link rel="stylesheet" href="/css/header.css">
+  <link rel="stylesheet" href="/css/footer.css">
+</head>
+<body>
+  <!-- HEADER -->
+  <div th:replace="fragments/header :: header"></div>
+
+  <!-- FORMULARIO -->
+  <main class="container my-5">
+    <div class="row justify-content-center">
+      <div class="col-md-8 col-lg-6">
+        <div class="card p-4 shadow-sm rounded-3">
+          <h2 class="mb-4 text-center" th:text="${partidoForm.idPartido != null} ? 'Editar Partido' : 'Crear Partido'"></h2>
+
+          <div class="alert alert-danger" th:if="${errorMessage}" th:text="${errorMessage}"></div>
+
+          <form th:action="@{${partidoForm.idPartido} != null ? 
+            '/torneos/' + ${partidoForm.torneoId} + '/partidos/' + ${partidoForm.idPartido} + '/actualizar' :
+            '/torneos/' + ${partidoForm.torneoId} + '/partidos/guardar'}"
+            th:object="${partidoForm}" method="post" class="needs-validation" novalidate>
+
+            <input type="hidden" th:field="*{idPartido}"/>
+            <input type="hidden" th:field="*{torneoId}"/>
+
+            <div class="mb-3">
+              <label class="form-label">Fecha</label>
+              <input type="datetime-local" th:field="*{fecha}" class="form-control"/>
+              <div class="text-danger small" th:if="${#fields.hasErrors('fecha')}" th:errors="*{fecha}"></div>
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Lugar</label>
+              <input type="text" th:field="*{lugar}" class="form-control"/>
+              <div class="text-danger small" th:if="${#fields.hasErrors('lugar')}" th:errors="*{lugar}"></div>
+            </div>
+
+            <div class="mb-3" th:if="${partidoForm.idPartido != null}">
+              <label class="form-label">Estado</label>
+              <select th:field="*{estadoPartido}" class="form-select">
+                <option value="PROGRAMADO">Programado</option>
+                <option value="CANCELADO">Cancelado</option>
+              </select>
+              <div class="text-danger small" th:if="${#fields.hasErrors('estadoPartido')}" th:errors="*{estadoPartido}"></div>
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Equipo Local</label>
+              <input type="text" th:field="*{equipoLocal}" class="form-control"/>
+              <div class="text-danger small" th:if="${#fields.hasErrors('equipoLocal')}" th:errors="*{equipoLocal}"></div>
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Equipo Visitante</label>
+              <input type="text" th:field="*{equipoVisitante}" class="form-control"/>
+              <div class="text-danger small" th:if="${#fields.hasErrors('equipoVisitante')}" th:errors="*{equipoVisitante}"></div>
+            </div>
+
+            <div class="d-grid mt-4">
+              <button type="submit" 
+                      class="btn btn-cta btn-md btn-caba-naranja"
+                      th:text="${partidoForm.idPartido != null} ? 'Actualizar' : 'Crear'">
+              </button>
+
+            </div>
+
+          </form>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <!-- FOOTER -->
+  <div th:replace="fragments/footer :: footer"></div>
+
+  <!-- Scripts -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/partidos/lista.html
+++ b/src/main/resources/templates/partidos/lista.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head><title>Lista de Partidos</title></head>
+<body>
+<h1>Lista de Partidos</h1>
+<a th:href="@{/partidos/nuevo}">Crear nuevo partido</a>
+<table border="1">
+    <thead>
+    <tr>
+        <th>ID</th><th>Fecha</th><th>Lugar</th><th>Estado</th>
+        <th>Local</th><th>Visitante</th><th>Torneo</th><th>Árbitros</th><th>Acciones</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="partido : ${partidos}">
+        <td th:text="${partido.idPartido}"></td>
+        <td th:text="${partido.fecha}"></td>
+        <td th:text="${partido.lugar}"></td>
+        <td th:text="${partido.estadoPartido}"></td>
+        <td th:text="${partido.equipoLocal}"></td>
+        <td th:text="${partido.equipoVisitante}"></td>
+        <td th:text="${partido.torneo.nombre}"></td>
+        <td>
+            <span th:each="arb : ${partido.arbitros}" th:text="${arb.nombre} + ' '"></span>
+        </td>
+        <td>
+            <a th:href="@{'/partidos/editar/' + ${partido.idPartido}}">Editar</a> |
+            <a th:href="@{'/partidos/eliminar/' + ${partido.idPartido}}"
+               onclick="return confirm('¿Eliminar este partido?');">Eliminar</a>
+            <a th:href="@{'/asignacion/crear?partidoId=' + ${partido.idPartido}}">Asignar árbitros</a>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/torneos/detalle.html
+++ b/src/main/resources/templates/torneos/detalle.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>CABA Pro - Detalle Torneo</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Bootstrap -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+
+  <!-- Estilos globales -->
+  <link rel="stylesheet" href="/css/globals.css">
+  <link rel="stylesheet" href="/css/header.css">
+  <link rel="stylesheet" href="/css/footer.css">
+
+  <!-- Bootstrap Icons -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+</head>
+<body>
+  <!-- HEADER -->
+  <div th:replace="fragments/header :: header"></div>
+
+  <!-- CONTENIDO -->
+  <main class="container my-5">
+    <!-- Título torneo -->
+    <div class="mb-4">
+      <h1 class="fw-bold text-success">
+        Detalle Torneo: <span th:text="${torneo.nombre}"></span>
+      </h1>
+      <p><strong>Categoría:</strong> <span th:text="${torneo.categoria}"></span></p>
+      <p><strong>Fecha inicio:</strong> <span th:text="${torneo.fechaInicio}"></span></p>
+      <p><strong>Fecha fin:</strong> <span th:text="${torneo.fechaFin}"></span></p>
+    </div>
+
+    <!-- Botón crear partido -->
+    <div class="d-flex justify-content-end mb-3">
+      <a th:href="@{'/torneos/' + ${torneo.idTorneo} + '/partidos/nuevo'}" 
+        class="btn btn-caba-verde btn-md">
+        <i class="bi bi-plus-circle"></i> Crear nuevo partido
+      </a>
+
+
+
+    </div>
+
+    <!-- Tabla de partidos -->
+    <div class="table-responsive shadow-sm rounded">
+      <table class="table table-hover table-bordered align-middle bg-white">
+        <thead class="table-success text-center">
+          <tr>
+            <th>ID</th>
+            <th>Fecha</th>
+            <th>Lugar</th>
+            <th>Estado</th>
+            <th>Local</th>
+            <th>Visitante</th>
+            <th>Árbitros</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr th:each="partido : ${partidos}">
+            <td th:text="${partido.idPartido}" class="text-center"></td>
+            <td th:text="${partido.fecha}"></td>
+            <td th:text="${partido.lugar}"></td>
+            <td th:text="${partido.estadoPartido}"></td>
+            <td th:text="${partido.equipoLocal}"></td>
+            <td th:text="${partido.equipoVisitante}"></td>
+            <td>
+              <span th:each="arb : ${partido.arbitros}" th:text="${arb.nombre} + ' '"></span>
+            </td>
+            <td class="text-center">
+              <!-- Editar -->
+              <a th:href="@{'/partidos/editar/' + ${partido.idPartido}}" 
+                 class="btn btn-sm btn-caba-naranja" title="Editar">
+                 <i class="bi bi-pencil-square"></i>
+              </a>
+              <!-- Eliminar -->
+              <a th:href="@{'/torneos/' + ${torneo.idTorneo} + '/partidos/eliminar/' + ${partido.idPartido}}"
+                onclick="return confirm('¿Eliminar este partido?');"
+                class="btn btn-sm btn-caba-peligro" title="Eliminar">
+                <i class="bi bi-trash"></i>
+              </a>
+
+              <!-- Asignar árbitros -->
+              <a th:href="@{'/asignacion/crear?partidoId=' + ${partido.idPartido}}"
+                 class="btn btn-sm btn-caba-verde" title="Asignar árbitros">
+                 <i class="bi bi-person-check"></i>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </main>
+
+  <!-- FOOTER -->
+  <div th:replace="fragments/footer :: footer"></div>
+
+  <!-- Scripts -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/torneos/form.html
+++ b/src/main/resources/templates/torneos/form.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title th:text="${torneoForm.idTorneo != null} ? 'Editar Torneo' : 'Crear Torneo'">Formulario Torneo</title>
+
+    <!-- Bootstrap -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <!-- Tipografía y colores globales -->
+    <link rel="stylesheet" href="/css/globals.css">
+    <link rel="stylesheet" href="/css/forms.css">
+    <link rel="stylesheet" href="/css/home.css">
+    <link rel="stylesheet" href="/css/header.css">
+    <link rel="stylesheet" href="/css/footer.css">
+</head>
+<body>
+    <!-- HEADER -->
+    <div th:replace="fragments/header :: header"></div>
+
+    <!-- FORMULARIO -->
+    <main class="container my-5">
+        <div class="row justify-content-center">
+            <div class="col-md-8 col-lg-6">
+                <div class="card p-4 shadow-sm rounded-3">
+                    <h2 class="mb-4 text-center" th:text="${torneoForm.idTorneo != null} ? 'Editar Torneo' : 'Crear Torneo'"></h2>
+
+                    <form th:action="@{${torneoForm.idTorneo != null} ? '/torneos/actualizar/' + ${torneoForm.idTorneo} : '/torneos/guardar'}"
+                        th:object="${torneoForm}" method="post" class="needs-validation" novalidate>
+
+                        <input type="hidden" th:field="*{idTorneo}"/>
+
+                        <!-- Nombre -->
+                        <div class="mb-3">
+                            <label for="nombre" class="form-label">Nombre:</label>
+                            <input type="text" id="nombre" th:field="*{nombre}" class="form-control"/>
+                            <div class="text-danger small" th:if="${#fields.hasErrors('nombre')}" th:errors="*{nombre}"></div>
+                        </div>
+
+                        <!-- Tipo de Torneo -->
+                        <div class="mb-3">
+                            <label for="tipoTorneo" class="form-label">Tipo de Torneo:</label>
+                            <select id="tipoTorneo" th:field="*{tipoTorneo}" class="form-select">
+                                <option th:each="tipo : ${T(com.proyecto.cabapro.enums.TipoTorneo).values()}"
+                                        th:value="${tipo}" th:text="${tipo}"></option>
+                            </select>
+                            <div class="text-danger small" th:if="${#fields.hasErrors('tipoTorneo')}" th:errors="*{tipoTorneo}"></div>
+                        </div>
+
+                        <!-- Categoría -->
+                        <div class="mb-3">
+                            <label for="categoria" class="form-label">Categoría:</label>
+                            <select id="categoria" th:field="*{categoria}" class="form-select">
+                                <option th:each="cat : ${T(com.proyecto.cabapro.enums.CategoriaTorneo).values()}"
+                                        th:value="${cat}" th:text="${cat}"></option>
+                            </select>
+                            <div class="text-danger small" th:if="${#fields.hasErrors('categoria')}" th:errors="*{categoria}"></div>
+                        </div>
+
+                        <!-- Fecha Inicio -->
+                        <div class="mb-3">
+                            <label for="fechaInicio" class="form-label">Fecha de Inicio:</label>
+                            <input type="datetime-local" id="fechaInicio" th:field="*{fechaInicio}" class="form-control"/>
+                            <div class="text-danger small" th:if="${#fields.hasErrors('fechaInicio')}" th:errors="*{fechaInicio}"></div>
+                        </div>
+
+                        <!-- Fecha Fin -->
+                        <div class="mb-3">
+                            <label for="fechaFin" class="form-label">Fecha de Fin:</label>
+                            <input type="datetime-local" id="fechaFin" th:field="*{fechaFin}" class="form-control"/>
+                            <div class="text-danger small" th:if="${#fields.hasErrors('fechaFin')}" th:errors="*{fechaFin}"></div>
+                            <div class="text-danger small" th:if="${#fields.hasErrors('fechasValidas')}" th:errors="*{fechasValidas}"></div>
+                        </div>
+
+                        <!-- Botón -->
+                        <div class="d-grid mt-4">
+                            <button type="submit" class="btn btn-cta btn-caba-verde btn-lg" th:text="${torneoForm.idTorneo != null} ? 'Actualizar' : 'Crear'"></button>
+                        </div>
+
+                    </form>
+                </div>
+            </div>
+        </div>
+    </main>
+
+
+    <!-- FOOTER -->
+    <div th:replace="fragments/footer :: footer"></div>
+
+    <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/torneos/lista.html
+++ b/src/main/resources/templates/torneos/lista.html
@@ -1,0 +1,89 @@
+
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>CABA Pro - Lista de Torneos</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Bootstrap -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+
+  <!-- Estilos globales -->
+  <link rel="stylesheet" href="/css/globals.css">
+  <link rel="stylesheet" href="/css/header.css">
+  <link rel="stylesheet" href="/css/footer.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+
+</head>
+<body>
+  <!-- HEADER -->
+  <div th:replace="fragments/header :: header"></div>
+
+  <!-- CONTENIDO -->
+  <main class="container my-5">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <h1 class="fw-bold">Lista de Torneos</h1>
+        <a th:href="@{/torneos/nuevo}" class="btn btn-caba-verde">
+            <i class="bi bi-plus-circle"></i> Crear nuevo torneo
+        </a>
+
+    </div>
+
+    <div class="table-responsive">
+      <table class="table table-striped table-hover align-middle shadow-sm bg-white rounded">
+        <thead class="table-success">
+          <tr>
+            <th>ID</th>
+            <th>Tipo</th>
+            <th>Categoría</th>
+            <th>Inicio</th>
+            <th>Fin</th>
+            <th class="text-center">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr th:each="torneo : ${torneos}">
+            <td th:text="${torneo.idTorneo}"></td>
+            <td th:text="${torneo.tipoTorneo}"></td>
+            <td th:text="${torneo.categoria}"></td>
+            <td th:text="${torneo.fechaInicio}"></td>
+            <td th:text="${torneo.fechaFin}"></td>
+            <td class="text-center">
+                <!-- Ver (verde identidad) -->
+                <a th:href="@{'/torneos/' + ${torneo.idTorneo}}" 
+                    class="btn btn-sm btn-caba-verde" 
+                    title="Ver">
+                    <i class="bi bi-eye"></i>
+                </a>
+
+                <!-- Editar (naranja identidad) -->
+                <a th:href="@{'/torneos/editar/' + ${torneo.idTorneo}}" 
+                    class="btn btn-sm btn-caba-naranja" 
+                    title="Editar">
+                    <i class="bi bi-pencil-square"></i>
+                </a>
+
+                <!-- Eliminar (rojo derivado) -->
+                <a th:href="@{'/torneos/eliminar/' + ${torneo.idTorneo}}"
+                    onclick="return confirm('¿Estás seguro de eliminar este torneo?');"
+                    class="btn btn-sm btn-caba-peligro" 
+                    title="Eliminar">
+                    <i class="bi bi-trash"></i>
+                </a>
+            </td>
+
+
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </main>
+
+  <!-- FOOTER -->
+  <div th:replace="fragments/footer :: footer"></div>
+
+  <!-- Scripts -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Este Pull Request introduce la estructura básica para gestionar torneos y partidos en la aplicación CABA PRO. Los cambios incluyen:

Modelos (Entities):

Torneo y Partido con sus relaciones (OneToMany y ManyToOne).

Enumeraciones para TipoTorneo, CategoriaTorneo y EstadoPartido.

Repositorios (Repositories):

TorneoRepository y PartidoRepository con consultas básicas y personalizadas para facilitar la obtención de datos según filtros (por torneo, estado, árbitro, etc.).

Controladores y Formularios:

TorneoController con endpoints para listar, crear, editar, actualizar y eliminar torneos.

Formularios TorneoForm y PartidoForm con validaciones para la captura de datos desde la interfaz de usuario.

Seguridad:

Actualización de SecurityConfig para permitir el acceso a /torneos/** y /partidos/** solo a usuarios con rol ADMIN.

Notas:

Esta implementación establece la base para funcionalidades futuras relacionadas con la gestión de torneos y partidos.

No se incluyen cambios en el flujo de login, registro o gestión de árbitros, garantizando que la autenticación y autorización existentes sigan funcionando.