### PR TITLE
Crear asignación y ver asignaciones en árbitro

### DIFF
--- a/src/main/java/com/proyecto/cabapro/controller/AsignacionAdminController.java
+++ b/src/main/java/com/proyecto/cabapro/controller/AsignacionAdminController.java
@@ -1,0 +1,57 @@
+package com.proyecto.cabapro.controller;
+
+import com.proyecto.cabapro.model.Asignacion;
+import com.proyecto.cabapro.model.Partido;
+import com.proyecto.cabapro.service.AsignacionService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/asignacion/crear")
+public class AsignacionAdminController {
+
+    private final AsignacionService asignacionService;
+
+    public AsignacionAdminController(AsignacionService asignacionService) {
+        this.asignacionService = asignacionService;
+    }
+
+    /**
+     * Formulario de creación (requiere ?partidoId=...):
+     * - Lista árbitros
+     * - Carga partido
+     * - Pasa: no disponibles, ya asignados, aceptadas, faltantes, especialidades ocupadas
+     */
+    @GetMapping
+    public String form(@RequestParam("partidoId") int partidoId, Model model) {
+        model.addAttribute("arbitros", asignacionService.listarArbitros());
+
+        Partido p = asignacionService.buscarPartido(partidoId); // lanza IllegalArgumentException si no existe
+        model.addAttribute("partido", p);
+
+        model.addAttribute("noDispIds", asignacionService.arbitrosNoDisponiblesIds(partidoId));
+        model.addAttribute("yaAsigIds", asignacionService.arbitrosYaAsignadosIds(partidoId));
+
+        model.addAttribute("aceptadas", asignacionService.listarAceptadasPorPartido(partidoId));
+        model.addAttribute("faltanEsp", asignacionService.especialidadesFaltantes(partidoId));
+        model.addAttribute("espOcupadas", asignacionService.especialidadesOcupadas(partidoId));
+
+        return "admin/asignacion/crearlo"; //  templates/admin/asignacion/crearlo.html
+    }
+
+    // Crear UNA asignación para el partido indicado. 
+    @PostMapping("/uno")
+    public String crearUna(@RequestParam("partidoId") int partidoId,
+                           @RequestParam("arbitroId") Integer arbitroId,
+                           RedirectAttributes ra) {
+        try {
+            Asignacion a = asignacionService.crearParaArbitroYPartido(arbitroId, partidoId);
+            ra.addFlashAttribute("msg", "Asignación creada (id=" + a.getId() + ")");
+        } catch (IllegalArgumentException ex) {
+            ra.addFlashAttribute("err", ex.getMessage());
+        }
+        return "redirect:/asignacion/crear?partidoId=" + partidoId;
+    }
+}

--- a/src/main/java/com/proyecto/cabapro/controller/AsignacionController.java
+++ b/src/main/java/com/proyecto/cabapro/controller/AsignacionController.java
@@ -1,0 +1,54 @@
+package com.proyecto.cabapro.controller;
+
+import com.proyecto.cabapro.service.AsignacionService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/arbitro/asignaciones")
+public class AsignacionController {
+
+    private final AsignacionService asignacionService;
+
+    public AsignacionController(AsignacionService asignacionService) {
+        this.asignacionService = asignacionService;
+    }
+
+    @GetMapping
+    public String vista(@AuthenticationPrincipal User principal,
+                        @RequestParam(value = "msg", required = false) String msg,
+                        @RequestParam(value = "err", required = false) String err,
+                        Model model) {
+
+        String correo = principal.getUsername();
+
+        model.addAttribute("arbitro", asignacionService.getArbitroActual(correo));
+        model.addAttribute("asignaciones", asignacionService.listarDelActual(correo));
+        model.addAttribute("msg", msg);
+        model.addAttribute("err", err);
+        return "arbitro/asignacion"; // templates/arbitro/asignacion.html
+    }
+
+    @PostMapping("/{id}/aceptar")
+    public String aceptar(@AuthenticationPrincipal User principal, @PathVariable Long id) {
+        try {
+            asignacionService.aceptar(principal.getUsername(), id);
+            return "redirect:/arbitro/asignaciones?msg=Asignacion aceptada";
+        } catch (IllegalArgumentException ex) {
+            return "redirect:/arbitro/asignaciones?err=" + ex.getMessage();
+        }
+    }
+
+    @PostMapping("/{id}/rechazar")
+    public String rechazar(@AuthenticationPrincipal User principal, @PathVariable Long id) {
+        try {
+            asignacionService.rechazar(principal.getUsername(), id);
+            return "redirect:/arbitro/asignaciones?msg=Asignacion rechazada";
+        } catch (IllegalArgumentException ex) {
+            return "redirect:/arbitro/asignaciones?err=" + ex.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/proyecto/cabapro/enums/EstadoAsignacion.java
+++ b/src/main/java/com/proyecto/cabapro/enums/EstadoAsignacion.java
@@ -1,0 +1,7 @@
+package com.proyecto.cabapro.enums;
+
+public enum EstadoAsignacion {
+    PENDIENTE, 
+    ACEPTADA, 
+    RECHAZADA
+}

--- a/src/main/java/com/proyecto/cabapro/model/Asignacion.java
+++ b/src/main/java/com/proyecto/cabapro/model/Asignacion.java
@@ -1,0 +1,64 @@
+package com.proyecto.cabapro.model;
+
+import com.proyecto.cabapro.enums.EstadoAsignacion;
+import jakarta.persistence.*;
+import java.math.BigDecimal;            
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "asignaciones")
+public class Asignacion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Árbitro dueño
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "arbitro_id", nullable = false)
+    private Arbitro arbitro;
+
+    // Partido asignado (OBLIGATORIO)
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "partido_id", nullable = false)
+    private Partido partido;
+
+    // Torneo (se toma del partido)
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "torneo_id", nullable = false)
+    private Torneo torneo;
+
+    // Fecha (copia de la fecha del partido)
+    private LocalDate fechaAsignacion;
+
+    @Enumerated(EnumType.STRING)
+    private EstadoAsignacion estado = EstadoAsignacion.PENDIENTE;
+
+    @Column(name = "monto", precision = 14, scale = 2, nullable = false)
+    private BigDecimal monto = BigDecimal.ZERO;      
+
+    public Asignacion() {}
+
+    public Asignacion(Arbitro arbitro, Partido partido) {
+        this.arbitro = arbitro;
+        this.partido = partido;
+        this.torneo  = partido.getTorneo();
+        this.fechaAsignacion = partido.getFecha().toLocalDate();
+        this.estado = EstadoAsignacion.PENDIENTE;
+        this.monto = BigDecimal.ZERO;                
+    }
+
+    public Long getId() { return id; }
+    public Arbitro getArbitro() { return arbitro; }
+    public void setArbitro(Arbitro arbitro) { this.arbitro = arbitro; }
+    public Partido getPartido() { return partido; }
+    public void setPartido(Partido partido) { this.partido = partido; }
+    public Torneo getTorneo() { return torneo; }
+    public void setTorneo(Torneo torneo) { this.torneo = torneo; }
+    public LocalDate getFechaAsignacion() { return fechaAsignacion; }
+    public void setFechaAsignacion(LocalDate fechaAsignacion) { this.fechaAsignacion = fechaAsignacion; }
+    public EstadoAsignacion getEstado() { return estado; }
+    public void setEstado(EstadoAsignacion estado) { this.estado = estado; }
+    public BigDecimal getMonto() { return monto; }
+    public void setMonto(BigDecimal monto) { this.monto = (monto != null ? monto : BigDecimal.ZERO); }
+}

--- a/src/main/java/com/proyecto/cabapro/repository/AsignacionRepository.java
+++ b/src/main/java/com/proyecto/cabapro/repository/AsignacionRepository.java
@@ -1,0 +1,32 @@
+package com.proyecto.cabapro.repository;
+
+import com.proyecto.cabapro.enums.EstadoAsignacion;
+import com.proyecto.cabapro.model.Arbitro;
+import com.proyecto.cabapro.model.Asignacion;
+import com.proyecto.cabapro.model.Partido;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AsignacionRepository extends JpaRepository<Asignacion, Long> {
+
+    // Para obtener una asignación por su ID y árbitro
+    // Verifica que la asignación pertenezca al árbitro antes de aceptarla o rechazarla
+    Optional<Asignacion> findByIdAndArbitro(Long id, Arbitro arbitro);
+
+    // Para listar las asignaciones de un árbitro
+    List<Asignacion> findByArbitroOrderByFechaAsignacionDesc(Arbitro arbitro);
+
+
+    // Para listar las aceptadas de un partido en (listarAceptadasPorPartido)
+    List<Asignacion> findByPartidoAndEstado(Partido partido, EstadoAsignacion estado);
+
+
+    // Para saber si un árbitro tiene una asignación para un partido
+    boolean existsByArbitroAndPartido(Arbitro arbitro, Partido partido);
+
+    // Para listar las asignaciones de un partido usado en (especialidas ocupadas)
+    List<Asignacion> findByPartido(Partido partido);
+
+}

--- a/src/main/java/com/proyecto/cabapro/service/AsignacionService.java
+++ b/src/main/java/com/proyecto/cabapro/service/AsignacionService.java
@@ -1,0 +1,215 @@
+package com.proyecto.cabapro.service;
+
+import com.proyecto.cabapro.enums.Especialidad;
+import com.proyecto.cabapro.enums.EstadoAsignacion;
+import com.proyecto.cabapro.model.Arbitro;
+import com.proyecto.cabapro.model.Asignacion;
+import com.proyecto.cabapro.model.Partido;
+import com.proyecto.cabapro.repository.AsignacionRepository;
+import com.proyecto.cabapro.repository.PartidoRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class AsignacionService {
+
+    private final AsignacionRepository asignacionRepo;
+    private final PartidoRepository partidoRepo;
+    private final ArbitroService arbitroService;
+
+    public AsignacionService(
+            AsignacionRepository asignacionRepo,
+            PartidoRepository partidoRepo,
+            ArbitroService arbitroService
+    ) {
+        this.asignacionRepo = asignacionRepo;
+        this.partidoRepo = partidoRepo;
+        this.arbitroService = arbitroService;
+    }
+
+    // ============== CREATE / UPDATE (dominio) ==============
+
+    /** Crear UNA asignación PENDIENTE (admin) */
+    public Asignacion crearParaArbitroYPartido(Integer arbitroId, int partidoId) {
+        Arbitro a = buscarArbitroOrThrow(arbitroId);
+        Partido p = buscarPartido(partidoId);
+        LocalDate f = fechaPartido(p);
+
+        validarPrecondicionesDeAsignacion(a, p, f);
+
+        return asignacionRepo.save(construirPendiente(a, p));
+    }
+
+    /** Transición: PENDIENTE -> ACEPTADA (desde el árbitro autenticado por correo) */
+    public void aceptar(String correo, Long asignacionId) {
+        Arbitro a = getArbitroActual(correo);
+        Asignacion asig = asignacionRepo.findByIdAndArbitro(asignacionId, a)
+                .orElseThrow(() -> new IllegalArgumentException("Asignación no encontrada."));
+        if (asig.getEstado() != EstadoAsignacion.PENDIENTE) {
+            throw new IllegalStateException("La asignación ya fue " + asig.getEstado());
+        }
+
+        asig.setEstado(EstadoAsignacion.ACEPTADA);
+        asignacionRepo.save(asig);
+
+        Partido p = asig.getPartido();
+        if (p.getArbitros().stream().noneMatch(x -> Objects.equals(x.getId(), a.getId()))) {
+            p.getArbitros().add(a);
+            partidoRepo.save(p);
+        }
+    }
+
+    /** Transición: PENDIENTE -> RECHAZADA (desde el árbitro autenticado por correo) */
+    public void rechazar(String correo, Long asignacionId) {
+        Arbitro a = getArbitroActual(correo);
+        Asignacion asig = asignacionRepo.findByIdAndArbitro(asignacionId, a)
+                .orElseThrow(() -> new IllegalArgumentException("Asignación no encontrada."));
+        if (asig.getEstado() != EstadoAsignacion.PENDIENTE) {
+            throw new IllegalStateException("La asignación ya fue " + asig.getEstado());
+        }
+
+        asig.setEstado(EstadoAsignacion.RECHAZADA);
+        asignacionRepo.save(asig);
+
+        Partido p = asig.getPartido();
+        p.getArbitros().removeIf(x -> Objects.equals(x.getId(), a.getId()));
+        partidoRepo.save(p);
+    }
+
+    // ======================= READ ========================
+    @Transactional(readOnly = true)
+    public List<Asignacion> listarDelActual(String correo) {
+        Arbitro a = getArbitroActual(correo);
+        return asignacionRepo.findByArbitroOrderByFechaAsignacionDesc(a);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Asignacion> listarAceptadasPorPartido(int partidoId) {
+        Partido p = buscarPartido(partidoId);
+        return asignacionRepo.findByPartidoAndEstado(p, EstadoAsignacion.ACEPTADA);
+    }
+
+    // ======= Soporte a vistas / consultas de dominio =======
+    @Transactional(readOnly = true)
+    public List<Arbitro> listarArbitros() {
+        return arbitroService.listar();
+    }
+
+    @Transactional(readOnly = true)
+    public Partido buscarPartido(int id) {
+        return partidoRepo.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Partido no encontrado."));
+    }
+
+    @Transactional(readOnly = true)
+    public Arbitro getArbitroActual(String correo) {
+        return arbitroService.getActual(correo);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean yaTieneAsignacion(Arbitro a, Partido p) {
+        return asignacionRepo.existsByArbitroAndPartido(a, p);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Especialidad> especialidadesOcupadas(int partidoId) {
+        Partido p = buscarPartido(partidoId);
+        EnumSet<Especialidad> out = EnumSet.noneOf(Especialidad.class);
+        for (Asignacion asg : asignacionRepo.findByPartido(p)) {
+            if (asg.getEstado() != EstadoAsignacion.RECHAZADA
+                    && asg.getArbitro() != null
+                    && asg.getArbitro().getEspecialidad() != null) {
+                out.add(asg.getArbitro().getEspecialidad());
+            }
+        }
+        return out;
+    }
+
+    @Transactional(readOnly = true)
+    public boolean especialidadOcupada(int partidoId, Especialidad esp) {
+        if (esp == null) return false;
+        return especialidadesOcupadas(partidoId).contains(esp);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Especialidad> especialidadesFaltantes(int partidoId) {
+        EnumSet<Especialidad> requeridas = EnumSet.of(
+                Especialidad.AUXILIAR,
+                Especialidad.PRINCIPAL,
+                Especialidad.CRONOMETRISTA,
+                Especialidad.APUNTADOR
+        );
+        for (Asignacion asg : listarAceptadasPorPartido(partidoId)) {
+            if (asg.getArbitro() != null && asg.getArbitro().getEspecialidad() != null) {
+                requeridas.remove(asg.getArbitro().getEspecialidad());
+            }
+        }
+        return new ArrayList<>(requeridas);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Integer> arbitrosNoDisponiblesIds(int partidoId) {
+        Partido p = buscarPartido(partidoId);
+        LocalDate f = fechaPartido(p);
+        return listarArbitros().stream()
+                .filter(a -> !disponible(a, f))
+                .map(Arbitro::getId)
+                .collect(Collectors.toSet());
+    }
+
+    @Transactional(readOnly = true)
+    public Set<Integer> arbitrosYaAsignadosIds(int partidoId) {
+        Partido p = buscarPartido(partidoId);
+        return listarArbitros().stream()
+                .filter(a -> yaTieneAsignacion(a, p))
+                .map(Arbitro::getId)
+                .collect(Collectors.toSet());
+    }
+
+    // =================== Helpers privados ===================
+    private Arbitro buscarArbitroOrThrow(Integer id) {
+        Arbitro a = arbitroService.buscar(id);
+        if (a == null) throw new IllegalArgumentException("Árbitro no encontrado.");
+        return a;
+    }
+
+    private void validarPrecondicionesDeAsignacion(Arbitro a, Partido p, LocalDate f) {
+        if (!disponible(a, f)) {
+            throw new IllegalArgumentException("El árbitro NO está disponible en la fecha del partido.");
+        }
+        if (yaTieneAsignacion(a, p)) {
+            throw new IllegalArgumentException("Este árbitro ya tiene asignación para ese partido.");
+        }
+        if (a.getEspecialidad() == null) {
+            throw new IllegalArgumentException("El árbitro no tiene especialidad definida.");
+        }
+        if (especialidadOcupada(p.getIdPartido(), a.getEspecialidad())) {
+            throw new IllegalArgumentException("Ya hay un " + a.getEspecialidad() + " para este partido.");
+        }
+    }
+
+    private LocalDate fechaPartido(Partido p) {
+        return p.getFecha().toLocalDate();
+    }
+
+    private boolean disponible(Arbitro a, LocalDate f) {
+        return a.getFechasDisponibles() != null && a.getFechasDisponibles().contains(f);
+    }
+
+    private Asignacion construirPendiente(Arbitro a, Partido p) {
+        Asignacion asg = new Asignacion();
+        asg.setArbitro(a);
+        asg.setPartido(p);
+        asg.setTorneo(p.getTorneo());
+        asg.setFechaAsignacion(fechaPartido(p));
+        asg.setEstado(EstadoAsignacion.PENDIENTE);
+        asg.setMonto(BigDecimal.ZERO); // sin Tarifa, monto fijo 0
+        return asg;
+    }
+}

--- a/src/main/resources/templates/admin/Asignacion/crearlo.html
+++ b/src/main/resources/templates/admin/Asignacion/crearlo.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Asignar árbitro a partido</title>
+
+  <!-- Bootstrap -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+
+  <!-- Estilos globales -->
+  <link rel="stylesheet" href="/css/globals.css">
+  <link rel="stylesheet" href="/css/forms.css">
+  <link rel="stylesheet" href="/css/home.css">
+  <link rel="stylesheet" href="/css/header.css">
+  <link rel="stylesheet" href="/css/footer.css">
+</head>
+<body>
+  <!-- HEADER -->
+  <div th:replace="fragments/header :: header"></div>
+
+  <main class="container my-5">
+    <div class="row justify-content-center">
+      <div class="col-lg-10">
+
+        <!-- Título -->
+        <div class="card p-4 shadow-sm rounded-3 mb-4">
+          <h2 class="mb-4 text-center">Asignar árbitro a partido</h2>
+
+          <!-- Mensajes -->
+          <p th:if="${msg}" class="text-success" th:text="${msg}"></p>
+          <p th:if="${err}" class="text-danger" th:text="${err}"></p>
+
+          <!-- Selector de partido (si aplicara como torneos) -->
+          <div th:if="${partido != null}">
+            <p class="mb-3">
+              <strong>Partido:</strong> 
+              <span th:text="${#temporals.format(partido.fecha,'yyyy-MM-dd HH:mm')}"></span>
+              — <span th:text="${partido.equipoLocal + ' vs ' + partido.equipoVisitante}"></span>
+              <span th:if="${partido.torneo != null}"> (<span th:text="${partido.torneo.nombre}"></span>)</span>
+            </p>
+          </div>
+
+          <!-- Formulario de asignación -->
+          <form th:action="@{/asignacion/crear/uno}" method="post" class="mb-4 needs-validation" novalidate>
+            <div th:if="${_csrf != null}">
+              <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+            </div>
+            <input type="hidden" name="partidoId" th:value="${partido.idPartido}"/>
+
+            <div class="mb-3">
+              <label for="arbitroId" class="form-label fw-bold">Árbitro</label>
+              <select id="arbitroId" name="arbitroId" class="form-select" required>
+                <option value="" disabled selected>— elegir —</option>
+
+                <optgroup label="Disponibles">
+                  <option th:each="a : ${arbitros}" 
+                          th:if="${
+                            (yaAsigIds == null or !yaAsigIds.contains(a.id))
+                            and (noDispIds == null or !noDispIds.contains(a.id))
+                            and (espOcupadas == null or a.especialidad == null or !espOcupadas.contains(a.especialidad))
+                          }"
+                          th:value="${a.id}" 
+                          th:text="${a.nombre + ' ' + a.apellido + ' — ' + (a.especialidad != null ? a.especialidad : 'Sin especialidad')}">
+                  </option>
+                </optgroup>
+
+                <optgroup label="Creada la asignación">
+                  <option th:each="a : ${arbitros}" th:if="${yaAsigIds != null and yaAsigIds.contains(a.id)}" 
+                          th:value="${a.id}" disabled
+                          th:text="${a.nombre + ' ' + a.apellido + ' — ' + (a.especialidad != null ? a.especialidad : 'Sin especialidad')}">
+                  </option>
+                </optgroup>
+
+                <optgroup label="No disponibles para la fecha">
+                  <option th:each="a : ${arbitros}" th:if="${noDispIds != null and noDispIds.contains(a.id)}" 
+                          th:value="${a.id}" disabled
+                          th:text="${a.nombre + ' ' + a.apellido + ' — ' + (a.especialidad != null ? a.especialidad : 'Sin especialidad')}">
+                  </option>
+                </optgroup>
+
+                <optgroup label="Especialidad ya cubierta">
+                  <option th:each="a : ${arbitros}" th:if="${espOcupadas != null and a.especialidad != null and espOcupadas.contains(a.especialidad)
+                                                   and (yaAsigIds == null or !yaAsigIds.contains(a.id))
+                                                   and (noDispIds == null or !noDispIds.contains(a.id))}" 
+                          th:value="${a.id}" disabled
+                          th:text="${a.nombre + ' ' + a.apellido + ' — ' + a.especialidad + ' [ESPEC. CUBIERTA]'}">
+                  </option>
+                </optgroup>
+
+              </select>
+            </div>
+
+            <div class="d-grid mt-3">
+              <button type="submit" class="btn btn-cta btn-caba-verde btn-lg">Crear</button>
+            </div>
+          </form>
+
+          <!-- Árbitros asignados -->
+          <div th:if="${aceptadas != null and !#lists.isEmpty(aceptadas)}" class="mt-4">
+            <h5>Árbitros asignados</h5>
+            <ul class="list-group list-group-flush">
+              <li class="list-group-item" th:each="asig : ${aceptadas}">
+                <strong th:text="${asig.arbitro.nombre + ' ' + asig.arbitro.apellido}"></strong>
+                — especialidad: <span th:text="${asig.arbitro.especialidad != null ? asig.arbitro.especialidad : '—'}"></span>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Especialidades faltantes / ok -->
+          <div class="mt-4">
+            <div th:if="${faltanEsp != null and !#lists.isEmpty(faltanEsp)}" class="text-danger fw-bold mb-2">
+              ⚠ Faltan especialidades:
+              <span th:each="e, st : ${faltanEsp}">
+                <strong th:text="${e}"></strong><span th:if="${!st.last}">, </span>
+              </span>
+            </div>
+            <div th:if="${faltanEsp != null and #lists.isEmpty(faltanEsp)}" class="text-success fw-bold mb-2">
+              ✔ Todas las especialidades requeridas están cubiertas.
+            </div>
+            <p class="mb-0"><em>¡Administrador! Solo un árbitro por especialidad por partido.</em></p>
+          </div>
+
+        </div>
+
+      </div>
+    </div>
+  </main>
+
+  <!-- FOOTER -->
+  <div th:replace="fragments/footer :: footer"></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/arbitro/asignacion.html
+++ b/src/main/resources/templates/arbitro/asignacion.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Mis asignaciones</title>
+
+  <!-- Bootstrap -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <!-- Tus estilos -->
+  <link rel="stylesheet" href="/css/globals.css">
+  <link rel="stylesheet" href="/css/home.css">
+  <link rel="stylesheet" href="/css/header.css">
+  <link rel="stylesheet" href="/css/footer.css">
+</head>
+<body>
+  <!-- HEADER -->
+  <div th:replace="fragments/header :: header"></div>
+
+  <main class="container my-5">
+    <div class="row justify-content-center">
+      <div class="col-lg-10">
+        <div class="card p-4 shadow-sm rounded-3">
+          <h2 class="mb-4 text-center">Mis Asignaciones</h2>
+
+          <!-- Mensajes -->
+          <div th:if="${msg}" class="alert alert-success" th:text="${msg}"></div>
+          <div th:if="${err}" class="alert alert-danger" th:text="${err}"></div>
+
+          <!-- Lista de asignaciones -->
+          <div th:if="${asignaciones != null and !#lists.isEmpty(asignaciones)}" class="list-group">
+            <div th:each="a : ${asignaciones}" class="asignacion-item list-group-item mb-3 shadow-sm rounded">
+              <div class="d-flex justify-content-between align-items-start">
+                <div>
+                  <p class="mb-1">
+                    <strong>Fecha:</strong>
+                    <span th:text="${#temporals.format(a.fechaAsignacion, 'dd/MM/yyyy')}">22/08/2025</span>
+                  </p>
+                  <p class="mb-1">
+                    <strong>Partido:</strong>
+                    <span th:text="${a.partido.equipoLocal + ' vs ' + a.partido.equipoVisitante}">A vs B</span>
+                  </p>
+                  <p class="mb-1">
+                    <strong>Torneo:</strong>
+                    <span th:text="${a.torneo != null ? a.torneo.nombre : '—'}">Nombre Torneo</span>
+                  </p>
+                  <p class="mb-1">
+                    <strong>Estado:</strong>
+                    <span th:text="${a.estado}">PENDIENTE</span>
+                  </p>
+                  <p class="mb-0">
+                    <strong>Monto:</strong>
+                    <span th:text="${a.monto != null ? '$ ' + #numbers.formatDecimal(a.monto,1,'POINT',2,'COMMA') : '—'}">$ 0,00</span>
+                  </p>
+                </div>
+
+                <!-- Botones solo si está PENDIENTE -->
+                <div th:if="${a.estado != null and a.estado.name() == 'PENDIENTE'}"
+                     class="d-flex flex-column gap-2">
+                  <form th:action="@{/arbitro/asignaciones/{id}/aceptar(id=${a.id})}" method="post">
+                    <input type="hidden" th:if="${_csrf != null}" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                    <button type="submit" class="btn btn-caba-verde btn-sm">Aceptar</button>
+                  </form>
+                  <form th:action="@{/arbitro/asignaciones/{id}/rechazar(id=${a.id})}" method="post">
+                    <input type="hidden" th:if="${_csrf != null}" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                    <button type="submit" class="btn btn-caba-peligro btn-sm">Rechazar</button>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Vacío -->
+          <p th:if="${asignaciones == null or #lists.isEmpty(asignaciones)}" class="text-center text-muted">
+            Aún no tienes asignaciones.
+          </p>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <!-- FOOTER -->
+  <div th:replace="fragments/footer :: footer"></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
En esta actualización se implementó la funcionalidad de creación y gestión de asignaciones para los árbitros.

Cambios principales

* Se agregó la opción de crear una asignación 
* Se desarrolló la funcionalidad para que el árbitro pueda aceptar o rechazar la asignación recibida.
* El monto queda en 0 (módulo de Tarifa pendiente).

Con esto, el sistema ahora permite una administración más completa de los partidos y la participación activa de los árbitros en su planificación.